### PR TITLE
Fix: convert string params to expected types using default_value

### DIFF
--- a/backend/app/services/dataflow_engine.py
+++ b/backend/app/services/dataflow_engine.py
@@ -469,6 +469,21 @@ class DataFlowEngine:
                     for param in op.get("params", {}).get("init", []):
                         param_name = param.get("name")
                         param_value = param.get("value")
+                        default_value = param.get("default_value")
+                        
+                        # Type coercion based on default_value type
+                        if param_value is not None and default_value is not None:
+                            default_type = type(default_value)
+                            if not isinstance(param_value, default_type):
+                                try:
+                                    if default_type == bool:
+                                        # Special handling: bool("false") returns True in Python
+                                        param_value = str(param_value).lower() in ("true", "1", "yes")
+                                    else:
+                                        param_value = default_type(param_value)
+                                    logger.debug(f"Coerced {param_name} to {default_type.__name__}: {param_value}")
+                                except (ValueError, TypeError):
+                                    logger.warning(f"Failed to coerce {param_name} to {default_type.__name__}")
                         
                         try:
                             if param_name == "llm_serving":
@@ -531,6 +546,20 @@ class DataFlowEngine:
                     for param in op.get("params", {}).get("run", []):
                         param_name = param.get("name")
                         param_value = param.get("value")
+                        default_value = param.get("default_value")
+                        
+                        # Type coercion based on default_value type
+                        if param_value is not None and default_value is not None:
+                            default_type = type(default_value)
+                            if not isinstance(param_value, default_type):
+                                try:
+                                    if default_type == bool:
+                                        param_value = str(param_value).lower() in ("true", "1", "yes")
+                                    else:
+                                        param_value = default_type(param_value)
+                                except (ValueError, TypeError):
+                                    pass
+                        
                         run_params[param_name] = param_value
                     
                     # 实例化 Operator

--- a/backend/app/services/dataflow_engine.py
+++ b/backend/app/services/dataflow_engine.py
@@ -20,6 +20,10 @@ from contextlib import redirect_stdout, redirect_stderr
 
 logger = get_logger(__name__)
 
+import inspect
+
+from app.services.param_coercion import coerce_param_value
+
 class DataFlowEngineError(Exception):
     """DataFlow Engine 自定义异常类"""
     def __init__(self, message: str, context: Dict[str, Any] = None, original_error: Exception = None):
@@ -464,26 +468,22 @@ class DataFlowEngine:
                 try:
                     init_params = {}
                     run_params = {}
+                    operator_cls_name = extract_class_name(op_name)
+                    operator_cls = OPERATOR_REGISTRY.get(operator_cls_name)
+                    if not operator_cls:
+                        raise DataFlowEngineError(
+                            f"Operator类未找到: {operator_cls_name}",
+                            context={"operator": op_name, "operator_index": op_idx}
+                        )
+
+                    init_sig = inspect.signature(getattr(operator_cls, "__init__", lambda: None))
+                    run_sig = inspect.signature(getattr(operator_cls, "run", lambda: None))
                     
                     # 处理 init 参数
                     for param in op.get("params", {}).get("init", []):
                         param_name = param.get("name")
                         param_value = param.get("value")
                         default_value = param.get("default_value")
-                        
-                        # Type coercion based on default_value type
-                        if param_value is not None and default_value is not None:
-                            default_type = type(default_value)
-                            if not isinstance(param_value, default_type):
-                                try:
-                                    if default_type == bool:
-                                        # Special handling: bool("false") returns True in Python
-                                        param_value = str(param_value).lower() in ("true", "1", "yes")
-                                    else:
-                                        param_value = default_type(param_value)
-                                    logger.debug(f"Coerced {param_name} to {default_type.__name__}: {param_value}")
-                                except (ValueError, TypeError):
-                                    logger.warning(f"Failed to coerce {param_name} to {default_type.__name__}")
                         
                         try:
                             if param_name == "llm_serving":
@@ -525,6 +525,9 @@ class DataFlowEngine:
                                         context={"operator": op_name, "param": param_name}
                                     )
                                 param_value = prompt_cls()
+                            else:
+                                ann = init_sig.parameters.get(param_name).annotation if param_name in init_sig.parameters else inspect.Parameter.empty
+                                param_value = coerce_param_value(param_value, annotation=ann, default_value=default_value)
                             
                             init_params[param_name] = param_value
                             
@@ -547,31 +550,11 @@ class DataFlowEngine:
                         param_name = param.get("name")
                         param_value = param.get("value")
                         default_value = param.get("default_value")
-                        
-                        # Type coercion based on default_value type
-                        if param_value is not None and default_value is not None:
-                            default_type = type(default_value)
-                            if not isinstance(param_value, default_type):
-                                try:
-                                    if default_type == bool:
-                                        param_value = str(param_value).lower() in ("true", "1", "yes")
-                                    else:
-                                        param_value = default_type(param_value)
-                                except (ValueError, TypeError):
-                                    pass
-                        
+                        ann = run_sig.parameters.get(param_name).annotation if param_name in run_sig.parameters else inspect.Parameter.empty
+                        param_value = coerce_param_value(param_value, annotation=ann, default_value=default_value)
                         run_params[param_name] = param_value
                     
                     # 实例化 Operator
-                    operator_cls_name = extract_class_name(op_name)
-                    operator_cls = OPERATOR_REGISTRY.get(operator_cls_name)
-                    
-                    if not operator_cls:
-                        raise DataFlowEngineError(
-                            f"Operator类未找到: {operator_cls_name}",
-                            context={"operator": op_name, "operator_index": op_idx}
-                        )
-                    
                     operator_instance = operator_cls(**init_params)
                     run_op.append((operator_instance, run_params, op_name, op_key))
                     

--- a/backend/app/services/param_coercion.py
+++ b/backend/app/services/param_coercion.py
@@ -1,0 +1,105 @@
+import inspect
+import json
+from typing import Any, Optional, get_origin
+
+from pydantic import TypeAdapter
+from pydantic_core import ValidationError
+
+
+_TRUE_STRINGS = {"true", "1", "yes", "y", "on"}
+_FALSE_STRINGS = {"false", "0", "no", "n", "off"}
+
+
+def _normalize_empty_string(value: Any) -> Any:
+    if isinstance(value, str) and value == "":
+        return None
+    return value
+
+
+def _fallback_coerce_by_default(value: Any, default_value: Any) -> Any:
+    """
+    Best-effort coercion when we don't have type annotations.
+    Uses default_value's runtime type as the target.
+    """
+    if value is None or default_value is None:
+        return value
+
+    default_type = type(default_value)
+    if isinstance(value, default_type):
+        return value
+
+    try:
+        if default_type is bool:
+            if isinstance(value, bool):
+                return value
+            if isinstance(value, (int, float)):
+                return bool(value)
+            if isinstance(value, str):
+                lowered = value.strip().lower()
+                if lowered in _TRUE_STRINGS:
+                    return True
+                if lowered in _FALSE_STRINGS:
+                    return False
+            # Unknown bool-ish string: keep original to avoid surprising flips
+            return value
+
+        if default_type in (list, dict) and isinstance(value, str):
+            # Try to parse JSON strings into containers.
+            parsed = json.loads(value)
+            if default_type is list and isinstance(parsed, list):
+                return parsed
+            if default_type is dict and isinstance(parsed, dict):
+                return parsed
+            return value
+
+        # For numeric / str-like types
+        return default_type(value)
+    except Exception:
+        return value
+
+
+def coerce_param_value(
+    value: Any,
+    *,
+    annotation: Any = inspect.Parameter.empty,
+    default_value: Any = None,
+) -> Any:
+    """
+    Coerce a single parameter value to the expected type.
+
+    Priority:
+    1) Use Pydantic TypeAdapter when annotation exists.
+       - validate_python for normal values
+       - validate_json when value is a JSON string (useful for list/dict/typed containers)
+    2) Fall back to coercion based on default_value runtime type.
+    """
+    value = _normalize_empty_string(value)
+
+    if value is not None and annotation is not inspect.Parameter.empty:
+        try:
+            adapter = TypeAdapter(annotation)
+            try:
+                return adapter.validate_python(value)
+            except ValidationError:
+                # If frontend sent JSON-as-string, attempt JSON validation for typed containers.
+                if isinstance(value, str):
+                    return adapter.validate_json(value)
+        except Exception:
+            # Any adapter/validation errors: fall back below.
+            pass
+
+    value = _fallback_coerce_by_default(value, default_value)
+
+    # If we still have a string that looks like JSON and default_value is an empty container
+    # without reliable typing, try a last resort parse for list/dict.
+    if isinstance(value, str) and default_value is not None:
+        origin = get_origin(annotation)
+        if origin in (list, dict) or isinstance(default_value, (list, dict)):
+            try:
+                parsed = json.loads(value)
+                return parsed
+            except Exception:
+                return value
+
+    return value
+

--- a/backend/app/services/ray_pipeline_executor.py
+++ b/backend/app/services/ray_pipeline_executor.py
@@ -267,8 +267,23 @@ def dataflow_pipeline_execute(pipeline_config: Dict[str, Any], dataflow_runtime:
                 for param in op.get("params", {}).get("init", []):
                     param_name = param.get("name")
                     param_value = param.get("value")
+                    default_value = param.get("default_value")
+                    
                     if isinstance(param_value, str) and param_value == "":
                         param_value = None
+                    
+                    # Type coercion based on default_value type
+                    if param_value is not None and default_value is not None:
+                        default_type = type(default_value)
+                        if not isinstance(param_value, default_type):
+                            try:
+                                if default_type == bool:
+                                    param_value = str(param_value).lower() in ("true", "1", "yes")
+                                else:
+                                    param_value = default_type(param_value)
+                                logger.debug(f"Coerced {param_name} to {default_type.__name__}: {param_value}")
+                            except (ValueError, TypeError):
+                                logger.warning(f"Failed to coerce {param_name} to {default_type.__name__}")
                     try:
                         if param_name == "llm_serving":
                             serving_id = param_value
@@ -427,6 +442,20 @@ def dataflow_pipeline_execute(pipeline_config: Dict[str, Any], dataflow_runtime:
                 for param in op.get("params", {}).get("run", []):
                     param_name = param.get("name")
                     param_value = param.get("value")
+                    default_value = param.get("default_value")
+                    
+                    # Type coercion based on default_value type
+                    if param_value is not None and default_value is not None:
+                        default_type = type(default_value)
+                        if not isinstance(param_value, default_type):
+                            try:
+                                if default_type == bool:
+                                    param_value = str(param_value).lower() in ("true", "1", "yes")
+                                else:
+                                    param_value = default_type(param_value)
+                            except (ValueError, TypeError):
+                                pass
+                    
                     if param.get('kind') == "VAR_KEYWORD":
                         for item in param_value:
                             run_params[item.get("name")] = item.get("value") if item.get("value") is not None else item.get("default_value")

--- a/backend/app/services/ray_pipeline_executor.py
+++ b/backend/app/services/ray_pipeline_executor.py
@@ -9,6 +9,7 @@ from typing import Dict, Any, Optional, List
 from app.core.config import settings
 import asyncio
 import json
+import inspect
 import os
 from datetime import datetime
 import traceback
@@ -17,6 +18,8 @@ import sys
 import re
 import time
 from contextlib import redirect_stdout, redirect_stderr
+
+from app.services.param_coercion import coerce_param_value
 
 logger = get_logger(__name__)
 
@@ -262,28 +265,22 @@ def dataflow_pipeline_execute(pipeline_config: Dict[str, Any], dataflow_runtime:
             try:
                 init_params = {}
                 run_params = {}
+
+                operator_cls_name = extract_class_name(op_name)
+                operator_cls = OPERATOR_REGISTRY.get(operator_cls_name)
+                if not operator_cls:
+                    raise DataFlowEngineError(
+                        f"Operator class not found: {operator_cls_name}",
+                        context={"operator": op_name, "operator_index": op_idx}
+                    )
+                init_sig = inspect.signature(getattr(operator_cls, "__init__", lambda: None))
+                run_sig = inspect.signature(getattr(operator_cls, "run", lambda: None))
                 
                 # 处理 init 参数
                 for param in op.get("params", {}).get("init", []):
                     param_name = param.get("name")
                     param_value = param.get("value")
                     default_value = param.get("default_value")
-                    
-                    if isinstance(param_value, str) and param_value == "":
-                        param_value = None
-                    
-                    # Type coercion based on default_value type
-                    if param_value is not None and default_value is not None:
-                        default_type = type(default_value)
-                        if not isinstance(param_value, default_type):
-                            try:
-                                if default_type == bool:
-                                    param_value = str(param_value).lower() in ("true", "1", "yes")
-                                else:
-                                    param_value = default_type(param_value)
-                                logger.debug(f"Coerced {param_name} to {default_type.__name__}: {param_value}")
-                            except (ValueError, TypeError):
-                                logger.warning(f"Failed to coerce {param_name} to {default_type.__name__}")
                     try:
                         if param_name == "llm_serving":
                             serving_id = param_value
@@ -421,6 +418,9 @@ def dataflow_pipeline_execute(pipeline_config: Dict[str, Any], dataflow_runtime:
                                 for param in param_value.get("params", []):
                                     param_dict[param.get("name")] = param.get("value") if param.get("value") is not None else param.get("default_value")
                                 param_value = prompt_cls(**param_dict)
+                        else:
+                            ann = init_sig.parameters.get(param_name).annotation if param_name in init_sig.parameters else inspect.Parameter.empty
+                            param_value = coerce_param_value(param_value, annotation=ann, default_value=default_value)
                         
                         init_params[param_name] = param_value
                         
@@ -443,35 +443,17 @@ def dataflow_pipeline_execute(pipeline_config: Dict[str, Any], dataflow_runtime:
                     param_name = param.get("name")
                     param_value = param.get("value")
                     default_value = param.get("default_value")
-                    
-                    # Type coercion based on default_value type
-                    if param_value is not None and default_value is not None:
-                        default_type = type(default_value)
-                        if not isinstance(param_value, default_type):
-                            try:
-                                if default_type == bool:
-                                    param_value = str(param_value).lower() in ("true", "1", "yes")
-                                else:
-                                    param_value = default_type(param_value)
-                            except (ValueError, TypeError):
-                                pass
-                    
                     if param.get('kind') == "VAR_KEYWORD":
                         for item in param_value:
-                            run_params[item.get("name")] = item.get("value") if item.get("value") is not None else item.get("default_value")
+                            item_name = item.get("name")
+                            item_val = item.get("value") if item.get("value") is not None else item.get("default_value")
+                            item_default = item.get("default_value")
+                            run_params[item_name] = coerce_param_value(item_val, annotation=inspect.Parameter.empty, default_value=item_default)
                     else:
-                        run_params[param_name] = param_value
+                        ann = run_sig.parameters.get(param_name).annotation if param_name in run_sig.parameters else inspect.Parameter.empty
+                        run_params[param_name] = coerce_param_value(param_value, annotation=ann, default_value=default_value)
                 
                 # 实例化 Operator
-                operator_cls_name = extract_class_name(op_name)
-                operator_cls = OPERATOR_REGISTRY.get(operator_cls_name)
-                
-                if not operator_cls:
-                    raise DataFlowEngineError(
-                        f"Operator class not found: {operator_cls_name}",
-                        context={"operator": op_name, "operator_index": op_idx}
-                    )
-                
                 operator_instance = operator_cls(**init_params)
                 run_op.append((operator_instance, run_params, op_name, op_key))
                 


### PR DESCRIPTION
## Problem

When running the **KBCleaning Pipeline** via WebUI, pipeline execution fails during `KBCChunkGenerator` initialization:

```
'<=' not supported between instances of 'str' and 'int'
```

## Root Cause Assumption
HTML form inputs serialize all user-modified values as strings. The backend receives mixed-type parameters without type validation, directly passing them to operator constructors.

For example:
- `chunk_size` was changed from the default `512` to `256` → received as `"256"` (str)
- `chunk_overlap` was left at the default `50` → retained as `50` (int)

When the operator internally performs numeric comparisons like `chunk_size <= max_tokens`, Python raises a `TypeError`.

## Solution

Add automatic type coercion in `dataflow_engine.py` and `ray_pipeline_executor.py` before passing params to operators. The coercion uses `default_value` to infer the expected type:

| Type | Coercion Rule |
|------|--------------|
| `int` / `float` | Cast via `int()` / `float()` |
| `bool` | Special handling — match against `"true"`, `"1"`, `"yes"` (since `bool("false")` returns `True` in Python) |
| Fallback | If coercion fails, log a warning and keep the original value |
