### PR TITLE
fix(api): keep /mcp responses as raw JSON-RPC, not ApiResponse envelope

### DIFF
--- a/backend/app/api/v1/handlers.py
+++ b/backend/app/api/v1/handlers.py
@@ -1,11 +1,21 @@
 # app/api/handlers.py
 from fastapi import FastAPI, Request
 from fastapi.exceptions import RequestValidationError
-from fastapi.responses import JSONResponse
+from fastapi.encoders import jsonable_encoder
+from fastapi.responses import JSONResponse, Response
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette import status
 from app.api.v1.envelope import ApiResponse
 from app.api.v1.errors import ApiError
+
+
+def _is_protocol_path(request: Request) -> bool:
+    """MCP (and other non-/api/v1) transport paths speak their own wire
+    protocol (e.g. JSON-RPC 2.0 over SSE). They must NOT be wrapped in the
+    WebUI ApiResponse envelope, otherwise clients like Cursor reject the
+    response with a JSON-RPC schema validation error."""
+    return request.url.path.startswith("/mcp")
+
 
 def install_exception_handlers(app: FastAPI):
 
@@ -23,6 +33,11 @@ def install_exception_handlers(app: FastAPI):
 
     @app.exception_handler(RequestValidationError)
     async def validation_error_handler(request: Request, exc: RequestValidationError):
+        if _is_protocol_path(request):
+            return JSONResponse(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                content={"detail": jsonable_encoder(exc.errors())},
+            )
         body = ApiResponse(
             success=False,
             code=42200,
@@ -34,6 +49,12 @@ def install_exception_handlers(app: FastAPI):
 
     @app.exception_handler(StarletteHTTPException)
     async def http_exception_handler(request: Request, exc: StarletteHTTPException):
+        if _is_protocol_path(request):
+            return JSONResponse(
+                status_code=exc.status_code,
+                content={"detail": exc.detail},
+                headers=getattr(exc, "headers", None),
+            )
         body = ApiResponse(
             success=False,
             code=exc.status_code * 100,
@@ -44,6 +65,8 @@ def install_exception_handlers(app: FastAPI):
 
     @app.exception_handler(Exception)
     async def unhandled_exception_handler(request: Request, exc: Exception):
+        if _is_protocol_path(request):
+            return Response(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
         # 兜底：未知异常
         body = ApiResponse(
             success=False,


### PR DESCRIPTION
MCP transport paths speak JSON-RPC 2.0; wrapping their error responses in the WebUI ApiResponse envelope makes strict clients (e.g. Cursor) reject them with a schema validation error. Skip envelope wrapping for /mcp in the exception handlers. /api/v1 behavior is unchanged.