### PR TITLE
Add compile key check + fix agent pipeline execution and WebUI chat UX

### DIFF
--- a/.claude/skills/generating-dataflow-pipeline/SKILL.md
+++ b/.claude/skills/generating-dataflow-pipeline/SKILL.md
@@ -171,6 +171,59 @@ When the pipeline is intended for WebUI execution (not local `python pipeline.py
 - Common failure: only the first operator gets a serving assigned; the rest remain empty, causing `Failed to process parameter: llm_serving` errors at execution time
 - In WebUI/MCP mode, older prompts may still say `list_servings`; the backend now provides both `list_serving` and a backward-compatible alias, but prefer `list_serving` in new prompts/skills
 
+### MCP `create_pipeline` config structure (MANDATORY — WebUI/MCP mode)
+
+When building a pipeline via the MCP `create_pipeline` / `update_pipeline` tools (NOT
+local codegen), the operator params JSON has two buckets — `init` and `run` — and
+**where each value goes is determined by the operator's real signature**, which you
+MUST fetch first with `get_operator_detail_by_name`. Getting this wrong makes the
+pipeline crash at execution time, not at create time.
+
+Hard rules:
+
+1. **LLM serving goes in `init.llm_serving`, as the serving *id* (not the name).**
+   Call `list_serving`, find the serving the user named, and use its `id`
+   (e.g. `"0510fc816d385c6f"`). NEVER put serving in a `run` param such as
+   `serving_name` — the operator's `run()` does not accept it and
+   `run(**run_params)` will raise "unexpected keyword argument".
+
+2. **`system_prompt` / `user_prompt` / `json_schema` / `prompt_template` are `init`
+   params, not `run` params** for generator operators (e.g. `PromptedGenerator`,
+   `ReasoningAnswerGenerator`). Only put a value in `run` if it appears in the
+   operator's `run()` signature returned by `get_operator_detail_by_name`.
+
+3. **Never send `None` (or empty string) for an optional text param that has a
+   non-empty default.** If you don't have a real `user_prompt`, OMIT the param
+   entirely so the operator uses its own default (e.g. `user_prompt=""`). Sending
+   `None` can cause `None + str` TypeErrors inside the operator.
+
+4. **`prompt_template` must be a plain allowed class name string** (e.g.
+   `"MathAnswerGeneratorPrompt"`), taken from the operator detail's
+   `allowed_prompts`. Do NOT send the `<class '...'>` repr — the validator rejects it.
+
+5. **Always call `validate_pipeline_config` before `create_pipeline`** and fix any
+   reported error (not just warnings) before creating.
+
+Minimal correct example (PromptedGenerator, one LLM op):
+
+```
+operators: [{
+  name: "PromptedGenerator",
+  params: {
+    init: [
+      { name: "llm_serving",   value: "<serving_id_from_list_serving>" },
+      { name: "system_prompt", value: "You are a helpful assistant." }
+      // user_prompt omitted -> operator default "" is used
+    ],
+    run: [
+      { name: "input_key",  value: "instruction" },
+      { name: "output_key", value: "generated_answer" }
+    ]
+  }
+}]
+```
+
+
 ## Standard Code Generation Rule (MANDATORY)
 
 **All generated Python code must follow the standard pipeline organization shown in the `examples/` folder of this skill package.**

--- a/.cursor/skills/generating-dataflow-pipeline/SKILL.md
+++ b/.cursor/skills/generating-dataflow-pipeline/SKILL.md
@@ -169,6 +169,22 @@ When the pipeline is intended for WebUI execution (not local `python pipeline.py
 - In the WebUI pipeline editor, assign the serving to **ALL** LLM-dependent operators (not just the first one)
 - Common failure: only the first operator gets a serving assigned; the rest remain empty, causing `Failed to process parameter: llm_serving` errors at execution time
 
+### MCP `create_pipeline` config structure (MANDATORY — WebUI/MCP mode)
+
+When building via MCP `create_pipeline`/`update_pipeline`, operator params split into
+`init` and `run`. Where each value goes is set by the operator's real signature —
+fetch it with `get_operator_detail_by_name` first. Wrong placement crashes at run time.
+
+1. **LLM serving → `init.llm_serving`, as the serving *id*** (from `list_serving`),
+   never a `run` param like `serving_name`.
+2. **`system_prompt`/`user_prompt`/`json_schema`/`prompt_template` are `init` params**
+   for generators; only put a key in `run` if it's in the operator's `run()` signature.
+3. **Never send `None`/empty for an optional text param with a non-empty default** —
+   omit it so the operator uses its default (avoids `None + str` TypeErrors).
+4. **`prompt_template` = plain allowed class name** (e.g. `"MathAnswerGeneratorPrompt"`),
+   from the operator detail's `allowed_prompts`; not the `<class '...'>` repr.
+5. **Call `validate_pipeline_config` before create**, fix errors first.
+
 ## Standard Code Generation Rule (MANDATORY)
 
 **All generated Python code must follow the standard pipeline organization shown in the `examples/` folder of this skill package.**

--- a/backend/app/services/agents/claude_adapter.py
+++ b/backend/app/services/agents/claude_adapter.py
@@ -49,10 +49,22 @@ class ClaudeAdapter(AgentAdapter):
             "--print", message,
             "--output-format", "stream-json",
             "--verbose",
+            # Emit partial message chunks (text_delta stream_events) as tokens
+            # arrive, instead of only whole `assistant` blocks after each turn.
+            # Without this the frontend receives text in one lump per turn and
+            # the chat never appears to "stream". _translate() already handles
+            # the stream_event/text_delta chunks. See buglog bug-004.
+            "--include-partial-messages",
             "--mcp-config", str(self.mcp_config_path),
             "--append-system-prompt", self.system_prompt,
             "--allowedTools", self.allowed_tools,
-            "--permission-mode", "dontAsk",
+            # acceptEdits (not dontAsk): dontAsk auto-approves MCP tools but
+            # DENIES the built-in Write/Edit tools, so the agent cannot create
+            # the dataset .jsonl files its skill requires — the turn then ends
+            # empty with stop_reason=None. acceptEdits auto-accepts file edits
+            # while keeping other guardrails, which fits this local pipeline-
+            # building workflow. See buglog bug-003.
+            "--permission-mode", "acceptEdits",
         ]
         if session_id:
             cmd += ["--resume", session_id]

--- a/backend/app/services/pipeline_compile_check.py
+++ b/backend/app/services/pipeline_compile_check.py
@@ -1,0 +1,144 @@
+"""Pipeline compile-time key check.
+
+Runs DataFlow's *real* ``PipelineABC.compile()`` key-integrity validation on a
+pipeline that has already been assembled by the Ray executor (operators
+instantiated, storage built). This is the same check DataFlow performs when a
+hand-written pipeline calls ``pipeline.compile()``:
+
+    for each operator, every ``input_*`` key must already exist in the
+    accumulated key set (dataset columns + upstream ``output_*`` keys);
+    otherwise ``compile()`` raises ``KeyError("Key Matching Error ...")``.
+
+The WebUI executor previously ran ``operator.run(**run_params)`` directly with
+no pre-check, so a broken key flow only surfaced as a mid-run crash. Calling
+``compile_check`` before the run loop makes "only runnable pipelines run".
+
+Why this does NOT execute the operators / call the LLM:
+``compile()`` first replaces every ``OperatorABC`` attribute on the pipeline
+with an ``AutoOP`` wrapper, then calls ``forward()``. ``AutoOP.run`` only
+*records* an ``OPRuntime`` (operator + kwargs) — it never invokes the operator's
+real logic. So ``forward()`` here just registers each op's key params; the
+actual key-graph validation happens in ``_build_operator_nodes_graph``.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from dataflow.pipeline import PipelineABC
+
+from app.core.logger_setup import get_logger
+
+logger = get_logger(__name__)
+
+
+def _key_params(run_params: Dict[str, Any]) -> Dict[str, Any]:
+    """Keep only the params DataFlow's OperatorNode treats as keys.
+
+    ``OperatorNode._get_keys_from_kwargs`` (dataflow/pipeline/nodes.py) only
+    looks at kwargs named ``input_*`` / ``output_*`` with string values. We pass
+    exactly those to ``AutoOP.run`` so the compile key graph matches what the
+    real run would produce, and we omit everything else (``storage`` is supplied
+    by ``forward``; other params would just bloat the bound signature).
+    """
+    out: Dict[str, Any] = {}
+    for name, value in run_params.items():
+        if name == "storage":
+            continue
+        if (name.startswith("input_") or name.startswith("output_")) and isinstance(value, str):
+            out[name] = value
+    return out
+
+
+def compile_check(run_op: List[Tuple[Any, Dict[str, Any], str, str]], storage: Any) -> Dict[str, Any]:
+    """Run DataFlow's compile() key validation on an assembled pipeline.
+
+    Args:
+        run_op: list of ``(operator_instance, run_params, op_name, op_key)`` as
+            built by the Ray executor.
+        storage: the ``FileStorage`` already pointing at the input dataset.
+
+    Returns a dict:
+        {"ok": bool, "detail": str, "errors": [ ... ], "skipped": bool}
+
+    ``skipped=True`` (with ok=True) means the check could not run for an
+    unexpected reason and was intentionally bypassed — the executor then
+    proceeds as before rather than failing on an infrastructure issue.
+    """
+    if not run_op:
+        return {"ok": True, "detail": "no operators", "errors": [], "skipped": False}
+
+    # Snapshot key params per operator BEFORE building the pipeline, since the
+    # executor mutates run_params["storage"] later.
+    ops_and_keys: List[Tuple[Any, Dict[str, Any], str]] = [
+        (operator, _key_params(run_params), op_name)
+        for (operator, run_params, op_name, _op_key) in run_op
+    ]
+
+    class _ConfigPipeline(PipelineABC):
+        def __init__(self, _storage, _ops_and_keys):
+            super().__init__()
+            self._df_storage = _storage
+            self._ordered = []  # (attr_name, key_params)
+            for idx, (operator, key_params, _op_name) in enumerate(_ops_and_keys):
+                attr = f"_op_{idx}"
+                # compile() scans vars(self) for OperatorABC instances and wraps
+                # them into AutoOP, so the operator must live as an attribute.
+                setattr(self, attr, operator)
+                self._ordered.append((attr, key_params))
+
+        def forward(self):
+            for attr, key_params in self._ordered:
+                op = getattr(self, attr)  # AutoOP wrapper at compile time
+                op.run(storage=self._df_storage.step(), **key_params)
+
+    try:
+        # storage.step() must not advance the real executor's storage: give
+        # compile a fresh reset copy. FileStorage.reset() returns self with the
+        # step counter reset; .step() then returns shallow copies.
+        compile_storage = storage.reset() if hasattr(storage, "reset") else storage
+        pipeline = _ConfigPipeline(compile_storage, ops_and_keys)
+        pipeline.compile()
+        # reset the executor's storage step counter back for the real run.
+        if hasattr(storage, "reset"):
+            storage.reset()
+        return {"ok": True, "detail": "compile key check passed", "errors": [], "skipped": False}
+
+    except KeyError as e:
+        # DataFlow raises KeyError with a "Key Matching Error ..." message that
+        # refers to operators by their internal attr name (_op_0, _op_1, ...).
+        # Map those back to the real operator names for a friendly message.
+        detail = str(e).strip().strip('"').strip("'")
+        for idx, (_operator, _kp, op_name) in enumerate(ops_and_keys):
+            detail = detail.replace(f"`_op_{idx}`", f"`{op_name}` (operator #{idx + 1})")
+            detail = detail.replace(f"_op_{idx}.run()", f"{op_name}.run()")
+        if hasattr(storage, "reset"):
+            try:
+                storage.reset()
+            except Exception:
+                pass
+        return {
+            "ok": False,
+            "detail": detail,
+            "errors": [{"message": detail}],
+            "skipped": False,
+        }
+
+    except Exception as e:
+        # Any non-KeyError problem (odd run signature, storage read issue, etc.)
+        # must NOT block execution — degrade to skip + warn, preserving prior
+        # behavior. compile is an added safety net, never a new failure point.
+        logger.warning(
+            f"[compile] key check skipped due to unexpected error: {e!r}",
+            exc_info=True,
+        )
+        if hasattr(storage, "reset"):
+            try:
+                storage.reset()
+            except Exception:
+                pass
+        return {
+            "ok": True,
+            "detail": f"compile check skipped: {e!r}",
+            "errors": [],
+            "skipped": True,
+        }

--- a/backend/app/services/pipeline_registry.py
+++ b/backend/app/services/pipeline_registry.py
@@ -1015,6 +1015,40 @@ class PipelineRegistry:
                         ))
 
             run_defs = (op_details.get("parameter") or {}).get("run", [])
+            # 提前拦截「run 里塞了算子 run() 签名之外的参数」这类错误。执行时
+            # operator.run(**run_params) 会因未知关键字参数直接崩溃，且真实异常
+            # 常被吞掉，所以在 validate 阶段就报 error，让 agent 能立即纠正。
+            # 常见误用：把 serving_name / system_prompt / user_prompt（其实属于
+            # init）塞进了 run。若算子 run() 声明了 **kwargs（VAR_KEYWORD）则放行。
+            run_def_names = {item.get("name") for item in run_defs if item.get("name")}
+            run_accepts_kwargs = any(
+                item.get("kind") == "VAR_KEYWORD" for item in run_defs
+            )
+            if run_def_names and not run_accepts_kwargs:
+                init_def_name_set = {item.get("name") for item in init_defs if item.get("name")}
+                for provided_name in run_params.keys():
+                    if provided_name in ("storage",):
+                        continue
+                    if provided_name not in run_def_names:
+                        belongs_to_init = provided_name in init_def_name_set
+                        hint = (
+                            f" 该参数其实属于该算子的 init 参数，请移到 init。"
+                            if belongs_to_init else
+                            f" 该算子 run() 只接受：{sorted(run_def_names)}。"
+                        )
+                        errors.append(self._make_validation_issue(
+                            level="error",
+                            code="unknown_run_param",
+                            message=(
+                                f"算子 '{op_name}' 的 run 参数 '{provided_name}' 不在 run() 签名中。"
+                                f"{hint}"
+                            ),
+                            operator_index=idx,
+                            operator_name=op_name,
+                            param_name=provided_name,
+                            available_fields=current_fields,
+                        ))
+
             for param_name, field_name in self._collect_input_field_refs(run_params, run_defs):
                 if current_fields and field_name not in current_fields:
                     suggested_fields, repair_hint = self._build_missing_input_field_hint(

--- a/backend/app/services/ray_pipeline_executor.py
+++ b/backend/app/services/ray_pipeline_executor.py
@@ -20,6 +20,7 @@ import time
 from contextlib import redirect_stdout, redirect_stderr
 
 from app.services.param_coercion import coerce_param_value
+from app.services.pipeline_compile_check import compile_check
 
 logger = get_logger(__name__)
 
@@ -275,12 +276,40 @@ def dataflow_pipeline_execute(pipeline_config: Dict[str, Any], dataflow_runtime:
                     )
                 init_sig = inspect.signature(getattr(operator_cls, "__init__", lambda: None))
                 run_sig = inspect.signature(getattr(operator_cls, "run", lambda: None))
-                
+                # 该算子的 run() 是否接受 **kwargs（VAR_KEYWORD）。若不接受，
+                # 则任何不在签名里的 run 参数都会导致 run(**run_params) 抛
+                # "unexpected keyword argument"。Agent 有时会把 serving_name /
+                # system_prompt / user_prompt 之类塞进 run 里（它们其实属于 init
+                # 或根本不存在），这里直接跳过并记日志，避免整条 pipeline 崩掉。
+                run_accepts_kwargs = any(
+                    p.kind == inspect.Parameter.VAR_KEYWORD
+                    for p in run_sig.parameters.values()
+                )
+
                 # 处理 init 参数
                 for param in op.get("params", {}).get("init", []):
                     param_name = param.get("name")
                     param_value = param.get("value")
                     default_value = param.get("default_value")
+                    # 若前端/agent 把某个 init 参数存成了 None，但算子 __init__ 对
+                    # 该参数有非 None 默认值（如 user_prompt=""），不要用 None 覆盖，
+                    # 否则算子内部像 `self.user_prompt + str(x)` 会抛
+                    # "unsupported operand type(s) for +: 'NoneType' and 'str'"。
+                    # 让算子用自己的默认值即可。（llm_serving 等有专门分支，不受影响）
+                    if (
+                        param_value is None
+                        and param_name not in ("llm_serving", "embedding_serving",
+                                               "process_fn", "filter_rules")
+                        and param_name in init_sig.parameters
+                        and init_sig.parameters[param_name].default
+                            not in (None, inspect.Parameter.empty)
+                    ):
+                        logger.info(
+                            f"Operator {op_name}: init param '{param_name}' is None; "
+                            f"keeping operator default "
+                            f"{init_sig.parameters[param_name].default!r}"
+                        )
+                        continue
                     try:
                         if param_name == "llm_serving":
                             serving_id = param_value
@@ -437,7 +466,23 @@ def dataflow_pipeline_execute(pipeline_config: Dict[str, Any], dataflow_runtime:
                         else:
                             ann = init_sig.parameters.get(param_name).annotation if param_name in init_sig.parameters else inspect.Parameter.empty
                             param_value = coerce_param_value(param_value, annotation=ann, default_value=default_value)
-                        
+
+                        # 若强制类型转换后得到 None（例如空字符串被 normalize 成
+                        # None），但算子对该参数有非 None 默认值，则不要用 None
+                        # 覆盖算子默认值，避免算子内部 `None + str` 之类崩溃。
+                        if (
+                            param_value is None
+                            and param_name in init_sig.parameters
+                            and init_sig.parameters[param_name].default
+                                not in (None, inspect.Parameter.empty)
+                        ):
+                            logger.info(
+                                f"Operator {op_name}: init param '{param_name}' resolved to "
+                                f"None; keeping operator default "
+                                f"{init_sig.parameters[param_name].default!r}"
+                            )
+                            continue
+
                         init_params[param_name] = param_value
                         
                     except DataFlowEngineError:
@@ -468,6 +513,14 @@ def dataflow_pipeline_execute(pipeline_config: Dict[str, Any], dataflow_runtime:
                             item_default = item.get("default_value")
                             run_params[item_name] = coerce_param_value(item_val, annotation=inspect.Parameter.empty, default_value=item_default)
                     else:
+                        # 跳过签名里不存在、且 run() 又不吃 **kwargs 的多余参数，
+                        # 否则 operator.run(**run_params) 会因未知关键字参数直接失败。
+                        if param_name not in run_sig.parameters and not run_accepts_kwargs:
+                            logger.warning(
+                                f"Operator {op_name}: dropping unknown run param "
+                                f"'{param_name}' (not in run() signature)"
+                            )
+                            continue
                         ann = run_sig.parameters.get(param_name).annotation if param_name in run_sig.parameters else inspect.Parameter.empty
                         run_params[param_name] = coerce_param_value(param_value, annotation=ann, default_value=default_value)
                 
@@ -493,6 +546,38 @@ def dataflow_pipeline_execute(pipeline_config: Dict[str, Any], dataflow_runtime:
                     },
                     original_error=e
                 )
+
+        # ── compile key 预检 ────────────────────────────────────────────
+        # 用已实例化的算子 + storage 跑一遍 DataFlow 官方的 compile() key 校验
+        # （与手写 pipeline 调 pipeline.compile() 完全等价）。任何算子的
+        # input_* key 若不在「数据集列 + 上游 output_* 产出」的累积集合里，就在
+        # 真正执行前拦下，给出精确的 key 错误——保证「能跑通的才跑」，而不是
+        # 跑到某个算子中途才崩。compile 只登记 key 图、不会真正执行算子/调 LLM。
+        try:
+            compile_result = compile_check(run_op, storage)
+        except Exception as _ce:
+            # 兜底:预检自身不该成为新的失败点
+            logger.warning(f"[compile] pre-check raised, skipping: {_ce!r}", exc_info=True)
+            compile_result = {"ok": True, "skipped": True, "detail": str(_ce), "errors": []}
+
+        if compile_result.get("skipped"):
+            add_log("init", f"[{datetime.now().isoformat()}] [compile] key check skipped: {compile_result.get('detail','')}")
+            logger.warning(f"[compile] key check skipped: {compile_result.get('detail','')}")
+        elif not compile_result["ok"]:
+            detail = compile_result.get("detail", "key matching error")
+            add_log("init", f"[{datetime.now().isoformat()}] [compile] key 校验未通过，已在执行前中止:\n{detail}")
+            logger.error(f"[compile] key check FAILED, aborting before run:\n{detail}")
+            raise DataFlowEngineError(
+                "Pipeline key 校验未通过（compile）——上游算子的 output key 与下游 input key 不匹配，已在执行前中止。",
+                context={
+                    "compile_errors": compile_result.get("errors", []),
+                    "detail": detail,
+                },
+            )
+        else:
+            add_log("init", f"[{datetime.now().isoformat()}] [compile] key check passed")
+            logger.info("[compile] key check passed")
+
         add_log("run", f"[{datetime.now().isoformat()}] Step 3: Executing {len(run_op)} operators...")
         logger.info(f"Executing {len(run_op)} operators...")
         
@@ -616,6 +701,12 @@ def dataflow_pipeline_execute(pipeline_config: Dict[str, Any], dataflow_runtime:
             except Exception as e:
                 operators_detail[op_key]["status"] = "failed"
                 operators_detail[op_key]["error"] = str(e)
+                # 记录真实异常的完整 traceback，否则只剩笼统的
+                # "执行Operator失败: X"，无法定位根因（见 bug 诊断）。
+                logger.error(
+                    f"Operator {op_name} run failed with underlying error: {e!r}",
+                    exc_info=True,
+                )
                 update_execution_status("failed", {
                     "operators_detail": operators_detail,
                     "operator_logs": operator_logs

--- a/frontend/src/components/manage/chatPanel/index.vue
+++ b/frontend/src/components/manage/chatPanel/index.vue
@@ -168,10 +168,10 @@
                     ref="inputRef"
                     v-model="inputText"
                     class="chat-input"
-                    :placeholder="isLoading ? '等待回复中...' : '输入你的需求，例如：帮我创建一个 QA 生成 pipeline...'"
-                    :disabled="isLoading"
-                    @keydown.enter.exact.prevent="sendMessage"
-                    @keydown.shift.enter="inputText += '\n'"
+                    :placeholder="isLoading ? '回复中，可继续输入下一条，待完成后发送…' : '输入你的需求，例如：帮我创建一个 QA 生成 pipeline...'"
+                    @keydown.enter.exact.prevent="onEnterKey"
+                    @compositionstart="isComposing = true"
+                    @compositionend="isComposing = false"
                     rows="3"
                 ></textarea>
                 <fv-button
@@ -251,6 +251,8 @@ export default {
             messages: [],
             inputText: '',
             isLoading: false,
+            // 中文/日文输入法组字状态：组字期间按 Enter 不应触发发送
+            isComposing: false,
             ws: null,
             userId: getUserId(),
             wsUrl: buildWsUrl(),
@@ -491,6 +493,12 @@ export default {
             this.$nextTick(() => this.scrollToBottom())
         },
 
+        onEnterKey() {
+            // 输入法组字/选字过程中的 Enter 不发送（避免把半成品和候选词误发）
+            if (this.isComposing) return
+            this.sendMessage()
+        },
+
         sendMessage() {
             const text = this.inputText.trim()
             if (!text || this.isLoading) return
@@ -593,6 +601,10 @@ export default {
     background: rgba(252, 252, 252, 1);
     border-left: 1px solid rgba(230, 230, 230, 1);
     font-size: 13px;
+    /* 锁定整个聊天面板的字体栈，避免继承全局那个本机不存在的 "Akkurat Std"
+       导致英文在个别浏览器/缓存状态下渲染异常。 */
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC",
+        "Microsoft YaHei", Roboto, Helvetica, Arial, sans-serif;
 }
 
 .chat-panel.dark {
@@ -759,6 +771,11 @@ export default {
     background: rgba(255, 255, 255, 1);
     border: 1px solid rgba(230, 230, 230, 1);
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+    /* 显式指定稳定的系统字体栈。全局用的 "Akkurat Std" 本机不存在也未加载，
+       fallback 链在不同浏览器上不确定，曾导致英文字符在个别环境下不显示。
+       这里锁定系统 UI 字体，中英文都稳定渲染。 */
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC",
+        "Microsoft YaHei", Roboto, Helvetica, Arial, sans-serif;
 }
 
 .dark .message-text {

--- a/frontend/src/hooks/dataflow/usePipelineOperation.js
+++ b/frontend/src/hooks/dataflow/usePipelineOperation.js
@@ -18,10 +18,10 @@ export function usePipelineOperation() {
         data.enableDelete = true
         // 获取指定ID的Vue Flow实例
         const flow = useVueFlow(flowId)
-        // 计算节点位置，Y轴添加随机偏移
+        // 计算节点位置
         const position = {
             x: data.location.x,
-            y: data.location.y + parseInt(5 * Math.random())
+            y: data.location.y
         }
         // 构建新节点对象
         const newNode = {
@@ -69,12 +69,15 @@ export function usePipelineOperation() {
         if (!pipelineConfig) return
 
         // 解析管道配置
-        const { input_dataset, operators } = pipelineConfig
-        // 设置节点基础位置
-        const basicPos = {
-            x: 350,
-            y: 0
-        }
+        // 兼容两种 input_dataset 形状：
+        //   - agent 通过 MCP create_pipeline 存的裸字符串 id（如 "3c0a5764ac"）
+        //   - 前端编辑器保存的对象 { id, location }
+        // 之前只认对象形状，agent 存字符串时 input_dataset.id === undefined，
+        // 导致 datasets.find 找不到、不建 dataset 节点、pipeline 在画布上是孤立算子。
+        const { input_dataset: _rawInputDataset, operators } = pipelineConfig
+        const input_dataset = (typeof _rawInputDataset === 'string')
+            ? { id: _rawInputDataset, location: undefined }
+            : (_rawInputDataset || {})
 
         // 查找输入数据集
         let dataset = datasets.find((item) => item.id === input_dataset.id)
@@ -133,20 +136,12 @@ export function usePipelineOperation() {
         formatOperators.sort((a, b) => a.pipeline_idx - b.pipeline_idx)
 
         // 处理每个操作符并添加到流程图中
+        // 自动水平布局：不信任存储/agent 给的坐标（agent 常把算子全存成同一竖列
+        // 导致重叠）。db-node 在最左(~x:50, y:160)，算子从其右侧起按固定间距等距
+        // 排开、纵向对齐成一条水平线，保证任何来源的 pipeline 都整齐不堆叠。
+        const LAYOUT = { startX: 350, gapX: 320, y: 160 }
         formatOperators.forEach((item, idx) => {
-            // 如果位置是数组格式，转换为对象格式
-            if (Array.isArray(item.location)) {
-                item.location = {
-                    x: item.location[0],
-                    y: item.location[1]
-                }
-            }
-            // 如果位置未设置或为0，计算默认位置
-            if (item.location.x === 0 || item.location.y === 0)
-                item.location = {
-                    x: idx === 0 ? basicPos.x : formatOperators[idx - 1].location.x + 350,
-                    y: basicPos.y
-                }
+            item.location = { x: LAYOUT.startX + idx * LAYOUT.gapX, y: LAYOUT.y }
             // 生成节点唯一ID
             item.nodeId = $Guid()
             // 添加节点到流程图
@@ -154,6 +149,10 @@ export function usePipelineOperation() {
         })
 
         // 检查是否存在数据集节点
+        // db-node 是通过 $emit('confirm-dataset') 跨组件异步添加的（父组件的
+        // updateDatabaseNode → flow.addNodes('db-node')），这里先等一个 tick，
+        // 确保它已进入 flow，否则首个算子会因找不到 db-node 而漏连输入边。
+        await $nextTick()
         let existsDatasetNode = flow.findNode('db-node')
 
         // 为操作符之间添加连接线

--- a/frontend/src/views/manage/dataflow/index.vue
+++ b/frontend/src/views/manage/dataflow/index.vue
@@ -84,7 +84,14 @@
         </div>
         <!-- AI Assistant Chat Panel -->
         <!-- 使用 v-show 而非 v-if：保持组件挂载状态，隐藏/显示时不销毁，对话历史不丢失 -->
-        <div v-show="show.chat" class="df-chat-container">
+        <div v-show="show.chat" class="df-chat-container" :style="{ width: chatWidth + 'px' }">
+            <!-- 左边缘拖拽手柄：按住左右拖动改变聊天面板宽度 -->
+            <div
+                class="df-chat-resizer"
+                :class="{ dragging: isResizingChat }"
+                title="拖动调整宽度"
+                @mousedown.prevent="startChatResize"
+            ></div>
             <chatPanel></chatPanel>
         </div>
         <page-loading :model-value="!lock.loading" title="Loading..."></page-loading>
@@ -152,6 +159,19 @@ import taskIcon from '@/assets/flow/task.svg'
 import saveIcon from '@/assets/flow/save.svg'
 
 import axios from '@/axios/config'
+
+// 聊天面板宽度持久化（跨刷新记住用户拖拽后的宽度）
+const CHAT_WIDTH_KEY = 'df_chat_width'
+const CHAT_WIDTH_DEFAULT = 320
+const CHAT_WIDTH_MIN = 280
+const CHAT_WIDTH_MAX = 900
+function getStoredChatWidth() {
+    try {
+        const v = parseInt(localStorage.getItem(CHAT_WIDTH_KEY), 10)
+        if (!isNaN(v)) return Math.min(CHAT_WIDTH_MAX, Math.max(CHAT_WIDTH_MIN, v))
+    } catch (e) { /* ignore */ }
+    return CHAT_WIDTH_DEFAULT
+}
 
 export default {
     name: "dataflowPage",
@@ -252,7 +272,11 @@ export default {
                 serving: true,
                 running: true,
                 loading: true
-            }
+            },
+            // 聊天面板宽度（可拖拽调整，跨刷新持久化）
+            chatWidth: getStoredChatWidth(),
+            isResizingChat: false,
+            _chatResizeState: null,
         }
     },
     watch: {
@@ -371,6 +395,11 @@ export default {
         this.getServing()
         this.getPromptInfo()
     },
+    beforeUnmount() {
+        // 兜底清理拖拽监听，避免组件销毁后仍挂在 window 上
+        window.removeEventListener('mousemove', this.onChatResize)
+        window.removeEventListener('mouseup', this.stopChatResize)
+    },
     methods: {
         ...mapActions(useDataflow, [
             'switchAutoConnection',
@@ -404,10 +433,14 @@ export default {
                     ...this.sourceDatabase
                 })
             } else {
-                let position = { x: 500, y: 160 }
-                if (this.sourceDatabase.location) {
-                    position.x = this.sourceDatabase.location[0]
-                    position.y = this.sourceDatabase.location[1]
+                let position = { x: 50, y: 160 }
+                // location 可能缺失、或 agent config 里是占位的 [0,0]；这两种
+                // 情况都用可见的默认位（算子节点在 x:350，dataset 放其左侧），
+                // 避免 db-node 落在 (0,0) 与视口/算子重叠而"看不见"。
+                const loc = this.sourceDatabase.location
+                if (Array.isArray(loc) && (loc[0] || loc[1])) {
+                    position.x = loc[0]
+                    position.y = loc[1]
                 }
                 flow.addNodes({
                     id: 'db-node',
@@ -878,6 +911,38 @@ export default {
                     flow.$reset()
                 }
             })
+        },
+        // ── 聊天面板拖拽调整宽度 ──────────────────────────────
+        startChatResize(event) {
+            this.isResizingChat = true
+            // 面板在右侧：手柄在左边缘，向左拖 => 变宽，所以用起始 X - 当前 X。
+            this._chatResizeState = {
+                startX: event.clientX,
+                startWidth: this.chatWidth,
+            }
+            window.addEventListener('mousemove', this.onChatResize)
+            window.addEventListener('mouseup', this.stopChatResize)
+            // 拖拽时禁止选中文字、统一光标
+            document.body.style.userSelect = 'none'
+            document.body.style.cursor = 'col-resize'
+        },
+        onChatResize(event) {
+            if (!this._chatResizeState) return
+            const delta = this._chatResizeState.startX - event.clientX
+            let next = this._chatResizeState.startWidth + delta
+            next = Math.min(CHAT_WIDTH_MAX, Math.max(CHAT_WIDTH_MIN, next))
+            this.chatWidth = next
+        },
+        stopChatResize() {
+            this.isResizingChat = false
+            this._chatResizeState = null
+            window.removeEventListener('mousemove', this.onChatResize)
+            window.removeEventListener('mouseup', this.stopChatResize)
+            document.body.style.userSelect = ''
+            document.body.style.cursor = ''
+            try {
+                localStorage.setItem(CHAT_WIDTH_KEY, String(this.chatWidth))
+            } catch (e) { /* ignore */ }
         }
     }
 }
@@ -942,6 +1007,42 @@ export default {
         overflow: hidden;
         box-shadow: -1px 0px 4px rgba(0, 0, 0, 0.08);
         margin-left: 10px;
+
+        .df-chat-resizer {
+            position: absolute;
+            left: 0px;
+            top: 0px;
+            width: 8px;
+            height: 100%;
+            cursor: col-resize;
+            z-index: 5;
+            /* 手柄本身透明，hover / 拖拽时高亮一条竖线 */
+            background: transparent;
+            transition: background 0.15s;
+
+            &::after {
+                content: '';
+                position: absolute;
+                left: 3px;
+                top: 50%;
+                transform: translateY(-50%);
+                width: 2px;
+                height: 40px;
+                border-radius: 2px;
+                background: rgba(120, 120, 120, 0.25);
+                transition: background 0.15s;
+            }
+
+            &:hover::after,
+            &.dragging::after {
+                background: rgba(69, 98, 213, 0.8);
+            }
+
+            &:hover,
+            &.dragging {
+                background: rgba(69, 98, 213, 0.06);
+            }
+        }
     }
 
     .control-menu-block {


### PR DESCRIPTION
Backend:
- claude_adapter: use --permission-mode acceptEdits (dontAsk denied Write, breaking dataset-file creation) and add --include-partial-messages so chat replies stream token-by-token.
- ray_pipeline_executor: run DataFlow's real compile() key-integrity check before executing operators (new pipeline_compile_check module) so key-flow breaks fail fast with a precise error instead of crashing mid-run; drop unknown run params not in the operator signature; keep operator defaults when a param coerces to None; log full traceback on operator failure.
- pipeline_registry: validate now flags run params outside the operator's run() signature as errors (unknown_run_param).

Frontend:
- usePipelineOperation: normalize input_dataset (agent stores a bare string id) so the dataset node renders and connects; always auto-layout operators horizontally (agent-stored coords stacked them in one column).
- chatPanel: guard Enter during IME composition so half-composed text isn't sent; allow typing while the agent runs; lock a stable system font stack; add a drag handle to resize the chat panel.
- dataflow view: resizable chat panel width (persisted); db-node position fallback so it stays visible and aligned.

Skills: document the MCP create_pipeline param-placement rules (serving in init.llm_serving as id, prompt_template as a plain class name, omit None).